### PR TITLE
Cleanup after Kovan test Pt.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can then run all tests with:
 ```
 
 ## Roadmap
-- [ ]  [Dynamic gas pricing strategy](https://github.com/makerdao/market-maker-keeper/blob/master/market_maker_keeper/gas.py)
+- [ ]  Asynchronous Transactions for improved performance
 - [ ]  Interactive startup (ask if cage has already been facilitated by the keeper)
 - [ ]  Call `Vow.heal()` and `End.thaw()` atomically
 - [ ]  Gas optimization (check to see if function has been called already, etc)

--- a/src/cage_keeper.py
+++ b/src/cage_keeper.py
@@ -113,7 +113,7 @@ class CageKeeper:
 
         # Create gas strategy
         if self.arguments.ethgasstation_api_key:
-            self.gas_price = DynamicGasPrice(self.arguments.ethgasstation_api_key)
+            self.gas_price = DynamicGasPrice(self.arguments)
         else:
             self.gas_price = DefaultGasPrice()
 
@@ -255,11 +255,13 @@ class CageKeeper:
 
         ilks = [self.dss.collaterals[key].ilk for key in self.dss.collaterals.keys()]
         ilksFiltered = list(filter(lambda l: l.name != 'SAI', ilks))
-        ilkNames = [i.name for i in deploymentIlksFiltered]
+        ilks_with_debt = list(filter(lambda l: self.dss.vat.ilk(l.name).art > Wad(0), ilksFiltered))
+
+        ilkNames = [i.name for i in ilks_with_debt]
 
         self.logger.info(f'Ilks to check: {ilkNames}')
 
-        return ilksFiltered
+        return ilks_with_debt
 
 
     def get_underwater_urns(self, ilks: List) -> List[Urn]:
@@ -290,7 +292,7 @@ class CageKeeper:
                     underwater_urns.append(urn)
                 i += 1;
 
-                if i % 10 == 0:
+                if i % 100 == 0:
                     self.logger.info(f'Processed {i} urns of {ilk.name}')
 
         return underwater_urns

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ docker-compose up -d
 sleep 2
 popd
 
-PYTHONPATH=$PYTHONPATH:./lib/pymaker:./lib/auction-keeper:./lib/ethgasstation-client py.test -s --cov=src --cov-report=term --cov-append tests/test_cageKeeper.py $@
+PYTHONPATH=$PYTHONPATH:./lib/pymaker:./lib/auction-keeper:./lib/pygasprice-client py.test -s --cov=src --cov-report=term --cov-append tests/test_cageKeeper.py $@
 TEST_RESULT=$?
 
 echo Stopping container

--- a/tests/test_cageKeeper.py
+++ b/tests/test_cageKeeper.py
@@ -279,40 +279,17 @@ pytest.global_auctions = {}
 
 class TestCageKeeper:
 
-    # @pytest.mark.skip(reason="done")
     def test_check_deployment(self, mcd: DssDeployment, keeper: CageKeeper):
         print_out("test_check_deployment")
         keeper.check_deployment()
 
-    def test_get_ilks(self, mcd: DssDeployment, keeper: CageKeeper):
-        print_out("test_get_ilks")
-
-        print(f"Dai: {mcd.vat.dai(mcd.vow.address)}")
-        print(f"Sin: {mcd.vat.sin(mcd.vow.address)}")
-        ilks = keeper.get_ilks()
-        assert type(ilks) is list
-        assert all(isinstance(x, Ilk) for x in ilks)
-        deploymentIlks = [mcd.vat.ilk(key) for key in mcd.collaterals.keys()]
-        assert all(elem in deploymentIlks for elem in ilks)
-
-    # @pytest.mark.skip(reason="done")
-    def test_check_ilks(self, mcd: DssDeployment, keeper: CageKeeper):
-        print_out("test_check_ilks")
-        ilks = keeper.check_ilks()
-        ilkNames = ilkNames = [i.name for i in ilks]
-        assert type(ilks) is list
-        assert all(isinstance(x, Ilk) for x in ilks)
-        deploymentIlkNames = [mcd.collaterals[key].ilk.name for key in mcd.collaterals.keys()]
-        assert set(ilkNames) == set(deploymentIlkNames)
-
-    # @pytest.mark.skip(reason="done")
     def test_get_underwater_urns(self, mcd: DssDeployment, keeper: CageKeeper, guy_address: Address, our_address: Address):
         print_out("test_get_underwater_urns")
 
         previous_eth_price = open_underwater_urn(mcd, mcd.collaterals['ETH-A'], guy_address)
         open_cdp(mcd, mcd.collaterals['ETH-C'], our_address)
 
-        ilks = keeper.check_ilks()
+        ilks = keeper.get_ilks()
 
         urns = keeper.get_underwater_urns(ilks)
         assert type(urns) is list
@@ -324,9 +301,18 @@ class TestCageKeeper:
 
         pytest.global_urns = urns
 
+    def test_get_ilks(self, mcd: DssDeployment, keeper: CageKeeper):
+        print_out("test_get_ilks")
 
+        ilks = keeper.get_ilks()
+        assert type(ilks) is list
+        assert all(isinstance(x, Ilk) for x in ilks)
+        deploymentIlks = [mcd.vat.ilk(key) for key in mcd.collaterals.keys()]
 
-    # @pytest.mark.skip(reason="done")
+        empty_deploymentIlks = list(filter(lambda l: mcd.vat.ilk(l.name).art == Wad(0), deploymentIlks))
+
+        assert all(elem not in empty_deploymentIlks for elem in ilks)
+
     def test_active_auctions(self, mcd: DssDeployment, keeper: CageKeeper, our_address: Address, other_address: Address, deployment_address: Address):
         print_out("test_active_auctions")
         print(f"Sin: {mcd.vat.sin(mcd.vow.address)}")
@@ -368,8 +354,6 @@ class TestCageKeeper:
 
         pytest.global_auctions = auctions
 
-
-    # @pytest.mark.skip(reason="done")
     def test_check_cage(self, mcd: DssDeployment, keeper: CageKeeper, our_address: Address, other_address: Address):
         print_out("test_check_cage")
         keeper.check_cage()
@@ -398,15 +382,13 @@ class TestCageKeeper:
 
         keeper.check_cage() # Facilitate cooldown (thawing cage)
 
-
-    # @pytest.mark.skip(reason="possibly incomplete")
     def test_cage_keeper(self, mcd: DssDeployment, keeper: CageKeeper, our_address: Address, other_address: Address):
         print_out("test_cage_keeper")
-        frobbedIlks = keeper.get_ilks()
+        ilks = keeper.get_ilks()
         urns = pytest.global_urns
         auctions = pytest.global_auctions
 
-        for ilk in frobbedIlks:
+        for ilk in ilks:
             # Check if cage(ilk) called on all ilks
             assert mcd.end.tag(ilk) > Ray(0)
 


### PR DESCRIPTION
Branch concludes small fixes from the end-to-end Kovan test, which verifies the previous improvements (dynamic gas price, vdb support, etc).

* Fixed gas_price assignment to accommodate unit tests
* Filter out ilks with no debt
* Fixed unit tests
* Add asynchronous tons in roadmap w/n readme

