### PR TITLE
update web3 configuration to support infura on mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Make a run-cage-keeper.sh to easily spin up the cage-keeper.
 ```
 #!/bin/bash
 /full/path/to/cage-keeper/bin/cage-keeper \
-	--rpc-host 'sample.ParityNode.com' \
+	--rpc-host 'https://sample.ParityNode.com:8545' \
 	--network 'kovan' \
 	--eth-from '0xABCAddress' \
 	--eth-key 'key_file=/full/path/to/keystoreFile.json,pass_file=/full/path/to/passphrase/file.txt' \


### PR DESCRIPTION
Updated web3 config to support infura nodes (e.g. `--rpc-host 'https://mainnet.infura.io/v3/a042c...`)

RPC endpoints to self-hosted nodes are still supported (e.g. `--rpc-host 'https://my.node.com:8545'`)

@jeannettemcd I changed the web3 config, so we need to ensure that our production instance is passing in the rpc-host (i.e. `SERVER_ETH_RPC_HOST`) in the correct format: e.g. `--rpc-host 'https://my.node.com:8545'`.