### PR TITLE
TECH-3595 - Setting correct CPU/RAM requests/limits

### DIFF
--- a/deploy/production/cage-keeper.yaml
+++ b/deploy/production/cage-keeper.yaml
@@ -16,11 +16,11 @@ podAnnotations:
   reloader.stakater.com/auto: "true"
 resources:
   limits:
-    cpu: 500m
-    memory: 1024Mi
+    cpu: 0.3
+    memory: 256Mi
   requests:
-    cpu: 250m
-    memory: 512Mi
+    cpu: 0.05
+    memory: 64Mi
 autoscaling:
   enabled: false
 env:


### PR DESCRIPTION
:chart_with_upwards_trend: :chart_with_upwards_trend: :chart_with_upwards_trend: 

Current average (12h) usage is:
**CPU**: 0.0042
**RAM**: 56.18 MB